### PR TITLE
DRAFT: validating queries from queries.json

### DIFF
--- a/load_queries.ts
+++ b/load_queries.ts
@@ -2,11 +2,11 @@ import * as fs from "fs";
 import * as path from "path";
 import { createClient } from "@clickhouse/client";
 
-const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL;
+const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL || 'https://sql-clickhouse.clickhouse.com';
 const CLICKHOUSE_USER = process.env.CLICKHOUSE_USER || 'default';
 const CLICKHOUSE_PASSWORD = process.env.CLICKHOUSE_PASSWORD;
 
-if (!CLICKHOUSE_URL || !CLICKHOUSE_USER || !CLICKHOUSE_PASSWORD) {
+if (!CLICKHOUSE_URL || !CLICKHOUSE_USER) {
   console.error("Environment variables CLICKHOUSE_URL, CLICKHOUSE_USER, and CLICKHOUSE_PASSWORD must be set");
   process.exit(1);
 }
@@ -16,7 +16,7 @@ console.log(`Running with CLICKHOUSE_URL: ${CLICKHOUSE_URL} and CLICKHOUSE_USER:
 const client = createClient({
   url: CLICKHOUSE_URL,
   username: CLICKHOUSE_USER,
-  password: CLICKHOUSE_PASSWORD
+  password: CLICKHOUSE_PASSWORD,
 });
 
 interface Query {
@@ -32,17 +32,41 @@ interface Query {
   params?: string
 }
 
-const loadQueries = async () => {
+async function loadQueries(validate = false) {
   const filePath = path.resolve(__dirname, "queries.json");
-  
+
   fs.readFile(filePath, "utf8", async (err, data) => {
     if (err) {
       console.error("Error reading file:", err);
       return;
     }
-    
+
     try {
       const queries = JSON.parse(data) as { queries: Query[] };
+
+      if (validate) {
+        const queryErrors: string[] = [];
+        for (const query of queries.queries) {
+          if (query.query.startsWith("SHOW") || query.group == "food" || query.query.startsWith("EXPLAIN")) {
+            continue
+          }
+
+          try {
+            console.log(`Validating query: ${query.name}`);
+            await client.exec({ query: `EXPLAIN ${query.query}` });
+          } catch (error) {
+            const errorMessage = `Error validating query ${query.name}: ${error.message}`;
+            queryErrors.push(errorMessage);
+            console.error(errorMessage);
+          }
+        }
+
+        for (const e of queryErrors) {
+          console.error(e);
+        }
+
+        return;
+      }
 
       // Create the temporary table
       await client.exec({
@@ -68,15 +92,15 @@ const loadQueries = async () => {
       // Insert data into the temporary table
       let i = 0;
       for (const query of queries.queries) {
-        const row:Query = {
+        const row: Query = {
           name: query.name,
           number: i,
           slug: query.slug,
           group: query.group,
           query: query.comment ? `--${query.comment}\n${query.query}` : query.query,
           chart: query.chart,
-          format: query.format ? true: false,
-          params: query.params ? query.params: "{}"
+          format: query.format ? true : false,
+          params: query.params ? query.params : "{}"
         };
         if (query.id) {
           row.id = query.id;
@@ -86,7 +110,7 @@ const loadQueries = async () => {
           values: [row],
           format: 'JSONEachRow',
         });
-        i+=1;
+        i += 1;
         console.log(`Inserted query: ${query.name} into queries_temp`);
       }
 
@@ -97,13 +121,14 @@ const loadQueries = async () => {
       // Drop the temporary table
       await client.exec({ query: `DROP TABLE default.queries_temp` });
       console.log("Dropped temporary table queries_temp");
-      
+
     } catch (error: unknown) {
-        console.log(error)
+      console.log(error)
     } finally {
       await client.close();
     }
   });
 };
 
-loadQueries();
+loadQueries(true);
+// await loadQueries();


### PR DESCRIPTION
Currently some queries don't work

see https://github.com/ClickHouse/sql.clickhouse.com/issues/17

related to https://github.com/ClickHouse/sql.clickhouse.com/issues/23

This is just a draft, to check if it is easy to validate these queries, @Blargian feel free to finish this PR and make it mergable, or close this PR. I will probably not be finishing these changes.

Also it looks like queries.json is outdated or it is not in sync with examples available https://sql.clickhouse.com. For example, I don't see `Recent releases for popular gems` in **Example queries** > **rubygems**

### all errors

```
Error validating query Airport with most departures: demo: Not enough privileges. To execute this query, it's necessary to have the grant SELECT(origin, longitude_1, latitude_1, longitude_2, latitude_2) ON opensky.opensky. 
Error validating query Recent releases: Substitution `packages` is not set. 
Error validating query Most liked posts: Timeout error.
Error validating query Top event types by count: Unknown expression or function identifier `posts` in scope SELECT event, sum(posts) AS posts FROM bluesky.top_event_types GROUP BY event ORDER BY posts DESC. Maybe you meant: ['posts']. 
Error validating query Gem downloads by version over time: demo: Not enough privileges. To execute this query, it's necessary to have the grant SELECT(`user_agent.ruby`, timestamp, gem) ON rubygems.downloads. (Missing permissions: SELECT(`user_agent.ruby`) ON rubygems.downloads). 
Error validating query Gem downloads by system over time: demo: Not enough privileges. To execute this query, it's necessary to have the grant SELECT(`user_agent.platform.os`, timestamp, gem) ON rubygems.downloads. (Missing permissions: SELECT(`user_agent.platform.os`) ON rubygems.downloads).
```