### PR TITLE
Add a workflow to build on a schedule via Git deploy hook

### DIFF
--- a/.github/build-on-schedule.yml
+++ b/.github/build-on-schedule.yml
@@ -1,0 +1,14 @@
+name: Trigger docs website build on schedule
+on:
+  schedule:
+    # First Monday of every month at 10:00 CET (09:00 UTC).
+    # Note: GitHub Actions has no timezone support; adjust to 08:00 UTC (0 8 1-7 * 1) during CEST (late Mar–late Oct).
+    - cron: '0 9 1-7 * 1'
+  workflow_dispatch:
+jobs:
+  build:
+    name: Trigger production build in Vercel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger build of sql.clickhouse.com
+        run: curl -X POST ${{ secrets.VERCEL_SQL_BUILD }}


### PR DESCRIPTION
Adds a workflow to trigger Vercel deploy via webhook once a month to keep the GitHub star count up to date.

`VERCEL_SQL_BUILD` secret needs to be added to Git for this to work.
It can be found in Vercel under **Settings** → **Git** → **Deploy hooks** (buttom of the page) → copy URL